### PR TITLE
Fix misleading message referring to a CodeBlock type

### DIFF
--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -198,7 +198,11 @@ func (a *step) buildWorkflow(builder wf.WorkflowBuilder) {
 
 	block, ok := de.Value.(px.OrderedMap)
 	if !ok {
-		panic(a.Error(de, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `CodeBlock`, `actual`: de.Value}))
+		// allow undef
+		if de.Value.Equals(px.Undef, nil) {
+			return
+		}
+		panic(a.Error(de, wf.FieldTypeMismatch, issue.H{`step`: a, `field`: `definition`, `expected`: `Hash`, `actual`: de.Value}))
 	}
 
 	// Block should only contain step expressions or something is wrong.


### PR DESCRIPTION
The term CodeBlock was interited from the puppet-workflow and has no
place in YAML. This commit also makes it possible to have a workflow
with zero number of steps.