### PR TITLE
Remove magic simplifications in favor of canonical syntax

### DIFF
--- a/schema/workflow.json
+++ b/schema/workflow.json
@@ -5,42 +5,35 @@
     "pcoreType":             {
       "description": "Pcore Type",
       "type": "string",
-      "pattern": "^[A-Z][\\w]*(?:::[A-Z][\\w]*)*(?:\\[.*\\])?"
+      "pattern": "^[A-Z][\\w]*(?:::[A-Z][\\w]*)*(?:\\[.*\\])?$"
     },
     "parameters": {
       "description": "Hash of named input parameters",
       "type": "object",
       "patternProperties": {
         "^[a-z_]\\w*$": {
-          "description": "Name of input parameter",
+          "description": "Parameter definition",
+          "type": "object",
           "oneOf": [
-            { "$ref": "#/definitions/pcoreType" },
             {
-              "description": "Parameter definition",
-              "type": "object",
-              "oneOf": [
-                {
-                  "properties": {
-                    "type": { "$ref": "#/definitions/pcoreType" },
-                    "lookup": {
-                      "description": "Hiera lookup key",
-                      "type": "string"
-                    }
-                  }
-                },
-                {
-                  "properties": {
-                    "type": { "$ref": "#/definitions/pcoreType" },
-                    "value": {
-                      "description": "Literal value or parameter reference"
-                    }
-                  }
+              "properties": {
+                "type": { "$ref": "#/definitions/pcoreType" },
+                "lookup": {
+                  "description": "Hiera lookup key",
+                  "type": "string"
                 }
-              ],
-              "minProperties": 1,
-              "additionalProperties": false
+              }
+            },
+            {
+              "properties": {
+                "type": { "$ref": "#/definitions/pcoreType" },
+                "value": {
+                  "description": "Literal value or parameter reference"
+                }
+              }
             }
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     },
@@ -56,13 +49,6 @@
               "pattern": "^[a-z_]\\w*$"
             }
           }
-        },
-        {
-          "description": "Hash, of typed output names",
-          "type": "object",
-          "patternProperties": {
-            "^[a-z_]\\w*$": { "$ref": "#/definitions/pcoreType" }
-        }
         },
         {
           "description": "Hash, of typed output definitions",
@@ -114,11 +100,14 @@
                   "$ref": "#/definitions/returns"
                 }
               ]
-            }
-          },
-          "patternProperties": {
-            "^[A-Z][\\w]*(?:::[A-Z][\\w]*)*$": {
+            },
+            "resource": {
               "description": "Name of Resource Type",
+              "type": "string",
+              "pattern": "^[A-Z][\\w]*(?:::[A-Z][\\w]*)*$"
+            },
+            "value": {
+              "description": "Desired state",
               "type": "object",
               "additionalProperties": false,
               "patternProperties": {
@@ -128,7 +117,9 @@
               }
             }
           },
-          "minProperties": 1,
+          "required": [
+            "resource"
+          ],
           "additionalProperties": false
         },
         {

--- a/yaml/activity_test.go
+++ b/yaml/activity_test.go
@@ -181,7 +181,7 @@ func ExampleCreateStep() {
 }
 
 func TestParse_unresolvedType(t *testing.T) {
-	requireError(t, `Reference to unresolved type 'No::Such::Type' (file: testdata/typefail.yaml, line: 3, column: 5)`, func() {
+	requireError(t, `Reference to unresolved type 'No::Such::Type' (file: testdata/typefail.yaml, line: 3, column: 15)`, func() {
 		pcore.Do(func(ctx px.Context) {
 			ctx.SetLoader(px.NewFileBasedLoader(ctx.Loader(), "./testdata", ``, px.PuppetDataTypePath))
 			workflowFile := "testdata/typefail.yaml"

--- a/yaml/testdata/attrfail.yaml
+++ b/yaml/testdata/attrfail.yaml
@@ -1,7 +1,8 @@
 steps:
   namespace:
     returns: no_such_attribute
-    Kubernetes::Namespace:
+    resource: Kubernetes::Namespace
+    value:
       namespace_id: "ignore"
       metadata:
         name: "terraform-lyra"

--- a/yaml/testdata/aws_vpc.yaml
+++ b/yaml/testdata/aws_vpc.yaml
@@ -3,12 +3,15 @@ parameters:
     type: Hash[String,String]
     lookup: aws.tags
 returns:
-  vpcId: String
-  subnetId: String
+  vpcId:
+    type: String
+  subnetId:
+    type: String
 steps:
   vpc:
     returns: vpcId
-    Aws::Vpc:
+    resource: Aws::Vpc
+    value:
       amazonProvidedIpv6CidrBlock: false
       cidrBlock: 192.168.0.0/16
       enableDnsHostnames: false
@@ -18,7 +21,8 @@ steps:
       tags: $tags
   subnet:
     returns: subnetId
-    Aws::Subnet:
+    resource: Aws::Subnet
+    value:
       vpcId: $vpcId
       cidrBlock: 192.168.1.0/24
       ipv6CidrBlock: ''

--- a/yaml/testdata/tf-k8s-sample.yaml
+++ b/yaml/testdata/tf-k8s-sample.yaml
@@ -1,9 +1,11 @@
 returns:
-  namespace_id: String
+  namespace_id:
+    type: String
 steps:
   namespace:
     returns: namespace_id
-    Kubernetes::Namespace:
+    resource: Kubernetes::Namespace
+    value:
       namespace_id: "ignore"
       metadata:
         name: "terraform-lyra"

--- a/yaml/testdata/typefail.yaml
+++ b/yaml/testdata/typefail.yaml
@@ -1,5 +1,6 @@
 steps:
   first:
-    No::Such::Type:
+    resource: No::Such::Type
+    value:
       one: two
       three: four


### PR DESCRIPTION
This commit removes the shorthand for declaring a typed parameter and
replaces the way a resource step was identified by a key that matched
a type name with an explicit `resource` and `value` key.

Closes lyraproj/lyra#309