### PR TITLE
Remove faulty fork of context

### DIFF
--- a/yaml/service.go
+++ b/yaml/service.go
@@ -67,7 +67,7 @@ func (m *manifestLoader) LoadManifest(moduleDir string, fileName string) service
 		panic(px.Error(px.UnableToReadFile, issue.H{`path`: fileName, `detail`: err.Error()}))
 	}
 
-	c := m.ctx.Fork()
+	c := m.ctx
 	mf := munged(fileName)
 	sb := service.NewServiceBuilder(c, mf)
 


### PR DESCRIPTION
This commit removes a faulty fork of the pcore context that occurred
when a manifest service was created and lead to problems when several
services shared the same parent context.

Closes lyraproj/lyra#312