### PR TITLE
Fix sane error message for steps missing required keyword

### DIFF
--- a/yaml/activity.go
+++ b/yaml/activity.go
@@ -120,8 +120,9 @@ func (a *step) stepKind() int {
 		if m.IncludesKey2(`resource`) {
 			return kindResource
 		}
+		panic(a.Error(a.hash, NotYamlStep, issue.NoArgs))
 	}
-	panic(a.Error(a.hash, wf.NotStep, issue.NoArgs))
+	panic(a.Error(a.hash, wf.NotStep, issue.H{`actual`: a.hash.Value}))
 }
 
 func (a *step) Step() wf.Step {

--- a/yaml/activity_test.go
+++ b/yaml/activity_test.go
@@ -180,6 +180,20 @@ func ExampleCreateStep() {
 	// )
 }
 
+func TestParse_oldSyntax(t *testing.T) {
+	requireError(t, `a step must contain one of the keys 'action', 'call', 'resource', or 'steps' (file: testdata/oldsyntax.yaml, line: 3, column: 5)`, func() {
+		pcore.Do(func(ctx px.Context) {
+			ctx.SetLoader(px.NewFileBasedLoader(ctx.Loader(), "./testdata", ``, px.PuppetDataTypePath))
+			workflowFile := "testdata/oldsyntax.yaml"
+			content, err := ioutil.ReadFile(workflowFile)
+			if err != nil {
+				panic(err.Error())
+			}
+			yaml.CreateStep(ctx, workflowFile, content)
+		})
+	})
+}
+
 func TestParse_unresolvedType(t *testing.T) {
 	requireError(t, `Reference to unresolved type 'No::Such::Type' (file: testdata/typefail.yaml, line: 3, column: 15)`, func() {
 		pcore.Do(func(ctx px.Context) {

--- a/yaml/issues.go
+++ b/yaml/issues.go
@@ -1,0 +1,9 @@
+package yaml
+
+import "github.com/lyraproj/issue/issue"
+
+const NotYamlStep = `YAML_NOT_STEP`
+
+func init() {
+	issue.Hard(NotYamlStep, `a step must contain one of the keys 'action', 'call', 'resource', or 'steps'`)
+}

--- a/yaml/testdata/oldsyntax.yaml
+++ b/yaml/testdata/oldsyntax.yaml
@@ -1,0 +1,5 @@
+steps:
+  first:
+    No::Such::Type:
+      one: two
+      three: four


### PR DESCRIPTION
A YAML step must contain one of the keywords 'action', 'call',
'resource', or 'steps'. A step that didn't would cause a panic with a
bogus error message. This commit ensures that the message is correct and
helpful